### PR TITLE
feat(ui): OrbitChat polished client-only UI\n\n- Replace Vite entry w…

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,13 +1,110 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" data-theme="dark">
   <head>
-    <meta charset="UTF-8" />
-    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>OpenChat</title>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>OrbitChat</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="/styles.css" />
   </head>
   <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
+    <div class="bg"></div>
+
+    <header class="topbar glass">
+      <div class="brand">
+        <div class="logo-orbit">
+          <span class="planet"></span>
+          <span class="ring"></span>
+        </div>
+        <h1>OrbitChat</h1>
+      </div>
+
+      <div class="search">
+        <svg width="18" height="18" viewBox="0 0 24 24" class="icon"><path d="M21 21l-4.35-4.35M10.5 18a7.5 7.5 0 1 1 0-15 7.5 7.5 0 0 1 0 15z" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+        <input id="searchInput" type="text" placeholder="Search chats or messages…" />
+      </div>
+
+      <div class="actions">
+        <button id="themeToggle" class="btn icon-btn" title="Toggle theme">
+          <span class="theme-sun">
+            <svg width="18" height="18" viewBox="0 0 24 24"><path d="M12 4V2m0 20v-2M4 12H2m20 0h-2M5 5 3.8 3.8M20.2 20.2 19 19M19 5l1.2-1.2M3.8 20.2 5 19M16 12a4 4 0 1 1-8 0 4 4 0 0 1 8 0z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>
+          </span>
+          <span class="theme-moon">
+            <svg width="18" height="18" viewBox="0 0 24 24"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z" fill="none" stroke="currentColor" stroke-width="1.7" stroke-linecap="round"/></svg>
+          </span>
+        </button>
+        <button id="clearAll" class="btn subtle">Clear</button>
+        <div class="me">
+          <img id="meAvatar" alt="Me" />
+        </div>
+      </div>
+    </header>
+
+    <main class="layout">
+      <aside class="sidebar glass">
+        <div class="sidebar-head">
+          <h2>Chats</h2>
+          <button id="newChat" class="btn primary">
+            <svg width="18" height="18" viewBox="0 0 24 24" class="icon"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+            New
+          </button>
+        </div>
+
+        <div id="chatList" class="chat-list"></div>
+      </aside>
+
+      <section class="chat glass">
+        <div id="emptyState" class="empty">
+          <div class="logo-big">
+            <div class="planet"></div>
+            <div class="ring"></div>
+          </div>
+          <h3>Welcome to OrbitChat</h3>
+          <p>Start a conversation from the left or create a new one.</p>
+        </div>
+
+        <div id="chatPane" class="chat-pane hidden">
+          <div class="chat-header">
+            <div class="chat-meta">
+              <img id="activeAvatar" class="avatar" alt="avatar" />
+              <div>
+                <h3 id="activeTitle" class="title">Chat</h3>
+                <div id="activeStatus" class="status">online</div>
+              </div>
+            </div>
+            <div class="chat-actions">
+              <button id="renameChat" class="btn subtle">Rename</button>
+              <button id="deleteChat" class="btn danger subtle">Delete</button>
+            </div>
+          </div>
+
+          <div id="messages" class="messages"></div>
+
+          <div class="composer">
+            <button id="attachBtn" class="btn icon-btn" title="Attach">
+              <svg width="18" height="18" viewBox="0 0 24 24" class="icon"><path d="M21.44 11.05 12.5 20a5 5 0 1 1-7.07-7.07l9.19-9.2a3.5 3.5 0 0 1 4.95 4.96L10.1 17.16A2 2 0 1 1 7.27 14.3l7.78-7.78" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+            </button>
+            <button id="emojiBtn" class="btn icon-btn" title="Emoji">😊</button>
+            <textarea id="messageInput" rows="1" placeholder="Message…" ></textarea>
+            <button id="micBtn" class="btn icon-btn" title="Voice">
+              <svg width="18" height="18" viewBox="0 0 24 24" class="icon"><path d="M12 14a3 3 0 0 0 3-3V7a3 3 0 0 0-6 0v4a3 3 0 0 0 3 3Zm7-3a7 7 0 0 1-14 0M12 21v-3" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round"/></svg>
+            </button>
+            <button id="sendBtn" class="btn primary" disabled>
+              <svg width="18" height="18" viewBox="0 0 24 24" class="icon"><path d="M22 2 11 13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/><path d="M22 2 15 22l-4-9-9-4 20-7Z" fill="currentColor" /></svg>
+              Send
+            </button>
+            <input type="file" id="fileInput" hidden />
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <button id="fabNew" class="fab primary">
+      <svg width="22" height="22" viewBox="0 0 24 24"><path d="M12 5v14M5 12h14" stroke="currentColor" stroke-width="2" stroke-linecap="round"/></svg>
+    </button>
+
+    <script type="module" src="/main.js"></script>
   </body>
 </html>

--- a/apps/web/main.js
+++ b/apps/web/main.js
@@ -1,0 +1,385 @@
+const $ = (q) => document.querySelector(q);
+const $$ = (q) => document.querySelectorAll(q);
+
+// Seed avatars and me
+const avatars = [
+  "https://i.pravatar.cc/100?img=5",
+  "https://i.pravatar.cc/100?img=32",
+  "https://i.pravatar.cc/100?img=15",
+  "https://i.pravatar.cc/100?img=49",
+  "https://i.pravatar.cc/100?img=68",
+  "https://i.pravatar.cc/100?img=23",
+];
+$("#meAvatar").src = "https://i.pravatar.cc/100?img=3";
+
+const storeKey = "orbit_state_v1";
+let state = loadState();
+
+function loadState() {
+  try {
+    const raw = localStorage.getItem(storeKey);
+    if (raw) return JSON.parse(raw);
+  } catch {}
+  const now = Date.now();
+  return {
+    activeId: null,
+    chats: [
+      {
+        id: id(),
+        name: "General",
+        avatar: avatars[0],
+        unread: 0,
+        messages: [
+          msg("other", "Hey, welcome to OrbitChat! ✨", now - 1000 * 60 * 12),
+          msg("me", "Thanks! UI looks cool already.", now - 1000 * 60 * 9),
+          msg("other", "Type a message below and hit Send.", now - 1000 * 60 * 8),
+        ],
+      },
+      {
+        id: id(),
+        name: "Project Orbit",
+        avatar: avatars[1],
+        unread: 1,
+        messages: [
+          msg("other", "Let’s ship the new design today.", now - 1000 * 60 * 40),
+          msg("me", "On it 🚀", now - 1000 * 60 * 35),
+        ],
+      },
+    ],
+    theme: "dark",
+  };
+}
+function saveState() {
+  localStorage.setItem(storeKey, JSON.stringify(state));
+}
+function id() {
+  return Math.random().toString(36).slice(2, 10);
+}
+function msg(who, text, t = Date.now()) {
+  return { id: id(), who, text, t, seen: who === "me" ? false : true, type: "text" };
+}
+
+const els = {
+  chatList: $("#chatList"),
+  chatPane: $("#chatPane"),
+  empty: $("#emptyState"),
+  messages: $("#messages"),
+  activeAvatar: $("#activeAvatar"),
+  activeTitle: $("#activeTitle"),
+  activeStatus: $("#activeStatus"),
+  search: $("#searchInput"),
+  newChat: $("#newChat"),
+  fabNew: $("#fabNew"),
+  renameChat: $("#renameChat"),
+  deleteChat: $("#deleteChat"),
+  messageInput: $("#messageInput"),
+  sendBtn: $("#sendBtn"),
+  attachBtn: $("#attachBtn"),
+  emojiBtn: $("#emojiBtn"),
+  micBtn: $("#micBtn"),
+  fileInput: $("#fileInput"),
+  themeToggle: $("#themeToggle"),
+  clearAll: $("#clearAll"),
+};
+
+init();
+function init() {
+  // Theme
+  setTheme(state.theme || "dark");
+  els.themeToggle.addEventListener("click", () => setTheme(toggleTheme()));
+
+  // Search
+  els.search.addEventListener("input", renderChatList);
+
+  // New chat buttons
+  els.newChat.addEventListener("click", createChatFlow);
+  els.fabNew.addEventListener("click", createChatFlow);
+
+  // Chat actions
+  els.renameChat.addEventListener("click", renameActiveChat);
+  els.deleteChat.addEventListener("click", deleteActiveChat);
+
+  // Composer
+  autosizeTextarea(els.messageInput);
+  els.messageInput.addEventListener("input", onComposerChanged);
+  els.messageInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      trySend();
+    }
+  });
+  els.sendBtn.addEventListener("click", trySend);
+  els.attachBtn.addEventListener("click", () => els.fileInput.click());
+  els.fileInput.addEventListener("change", onFilePicked);
+  els.emojiBtn.addEventListener("click", insertEmoji);
+  els.micBtn.addEventListener("click", () => toast("Voice recording not wired yet 🔈"));
+
+  // Clear all (for demo)
+  $("#clearAll").addEventListener("click", () => {
+    if (confirm("Clear all local chats?")) {
+      localStorage.removeItem(storeKey);
+      state = loadState();
+      renderAll();
+      toast("Cleared");
+    }
+  });
+
+  renderAll();
+}
+
+function renderAll() {
+  renderChatList();
+  renderActiveChat();
+}
+
+// Sidebar list
+function renderChatList() {
+  const q = (els.search.value || "").toLowerCase().trim();
+  const frag = document.createDocumentFragment();
+
+  state.chats
+    .map((c) => ({
+      ...c,
+      lastText:
+        c.messages.length ? c.messages[c.messages.length - 1].text.replace(/\s+/g, " ") : "No messages yet",
+    }))
+    .filter((c) => !q || c.name.toLowerCase().includes(q) || c.lastText.toLowerCase().includes(q))
+    .forEach((c) => {
+      const item = document.createElement("div");
+      item.className = "chat-item" + (state.activeId === c.id ? " active" : "");
+      item.innerHTML = `
+        <img class="avatar" src="${c.avatar}" alt="">
+        <div class="info">
+          <div class="name">${escapeHtml(c.name)}</div>
+          <div class="preview">${escapeHtml(c.lastText)}</div>
+        </div>
+        <div class="right">${c.unread ? `<span class="badge">${c.unread}</span>` : ""}</div>
+      `;
+      item.addEventListener("click", () => setActiveChat(c.id));
+      frag.appendChild(item);
+    });
+
+  els.chatList.innerHTML = "";
+  els.chatList.appendChild(frag);
+}
+
+// Active chat
+function renderActiveChat() {
+  const c = state.chats.find((x) => x.id === state.activeId);
+  if (!c) {
+    els.empty.classList.remove("hidden");
+    els.chatPane.classList.add("hidden");
+    return;
+  }
+  els.empty.classList.add("hidden");
+  els.chatPane.classList.remove("hidden");
+
+  c.unread = 0;
+  els.activeAvatar.src = c.avatar;
+  els.activeTitle.textContent = c.name;
+  els.activeStatus.textContent = "online";
+
+  // messages
+  const frag = document.createDocumentFragment();
+  let prevDay = "";
+  c.messages.forEach((m) => {
+    const day = new Date(m.t).toDateString();
+    if (day !== prevDay) {
+      const d = document.createElement("div");
+      d.className = "day-sep";
+      d.textContent = new Date(m.t).toLocaleDateString(undefined, { month: "short", day: "numeric" });
+      frag.appendChild(d);
+      prevDay = day;
+    }
+    const row = document.createElement("div");
+    row.className = "msg-row " + (m.who === "me" ? "me" : "other");
+
+    const bubble = document.createElement("div");
+    bubble.className = "msg " + (m.who === "me" ? "me" : "other");
+    bubble.innerHTML = `
+      <div class="txt">${linkify(escapeHtml(m.text))}</div>
+      <div class="meta">
+        <span>${timeStr(m.t)}</span>
+        ${m.who === "me" ? `<span class="dot"></span><span>${m.seen ? "seen" : "sent"}</span>` : ""}
+      </div>
+    `;
+    row.appendChild(bubble);
+    frag.appendChild(row);
+  });
+
+  els.messages.innerHTML = "";
+  els.messages.appendChild(frag);
+  scrollToBottom();
+}
+
+// Actions
+function setActiveChat(idVal) {
+  state.activeId = idVal;
+  saveState();
+  renderChatList();
+  renderActiveChat();
+}
+function createChatFlow() {
+  const name = prompt("Name this chat:");
+  if (!name) return;
+  const c = {
+    id: id(),
+    name: name.trim(),
+    avatar: avatars[Math.floor(Math.random() * avatars.length)],
+    unread: 0,
+    messages: [msg("other", `You created "${name.trim()}". Say hi! 👋`)],
+  };
+  state.chats.unshift(c);
+  state.activeId = c.id;
+  saveState();
+  renderAll();
+  toast("Chat created");
+}
+function renameActiveChat() {
+  const c = currentChat();
+  if (!c) return;
+  const next = prompt("Rename chat:", c.name);
+  if (!next) return;
+  c.name = next.trim();
+  saveState();
+  renderAll();
+}
+function deleteActiveChat() {
+  const c = currentChat();
+  if (!c) return;
+  if (!confirm(`Delete "${c.name}"?`)) return;
+  state.chats = state.chats.filter((x) => x.id !== c.id);
+  state.activeId = state.chats[0]?.id || null;
+  saveState();
+  renderAll();
+}
+
+function onComposerChanged() {
+  els.sendBtn.disabled = !els.messageInput.value.trim();
+  autoGrow(els.messageInput);
+}
+function trySend() {
+  const c = currentChat();
+  if (!c) return toast("Create/select a chat first");
+  const text = els.messageInput.value.trim();
+  if (!text) return;
+
+  const m = msg("me", text);
+  c.messages.push(m);
+  els.messageInput.value = "";
+  els.sendBtn.disabled = true;
+  autoGrow(els.messageInput);
+  saveState();
+  renderActiveChat();
+
+  // simulate "typing" indicator then reply
+  showTyping(c.id);
+  setTimeout(() => {
+    hideTyping(c.id);
+    const reply = msg("other", autoReply(text));
+    c.messages.push(reply);
+    // mark previous my last message as seen
+    m.seen = true;
+    saveState();
+    renderActiveChat();
+  }, 800 + Math.random() * 800);
+}
+function onFilePicked(e) {
+  const f = e.target.files?.[0];
+  if (!f) return;
+  els.messageInput.value += (els.messageInput.value ? " " : "") + `[attachment: ${f.name}]`;
+  onComposerChanged();
+  e.target.value = "";
+}
+function insertEmoji() {
+  const add = ["😊", "✨", "🚀", "🔥", "👍", "🤝"][Math.floor(Math.random() * 6)];
+  const el = els.messageInput;
+  const start = el.selectionStart ?? el.value.length;
+  el.value = el.value.slice(0, start) + add + el.value.slice(start);
+  onComposerChanged();
+  el.focus();
+  el.selectionStart = el.selectionEnd = start + add.length;
+}
+
+// Typing indicator
+let typingFor = null;
+function showTyping(chatId) {
+  typingFor = chatId;
+  const c = state.chats.find((x) => x.id === chatId);
+  if (!c) return;
+  const row = document.createElement("div");
+  row.className = "msg-row";
+  row.dataset.typing = "1";
+  const bubble = document.createElement("div");
+  bubble.className = "msg other";
+  bubble.innerHTML = `<div class="typing"><span></span><span></span><span></span></div>`;
+  row.appendChild(bubble);
+  els.messages.appendChild(row);
+  scrollToBottom();
+}
+function hideTyping(chatId) {
+  if (typingFor !== chatId) return;
+  $$('[data-typing="1"]').forEach((n) => n.remove());
+  typingFor = null;
+}
+
+// Helpers
+function currentChat() {
+  return state.chats.find((x) => x.id === state.activeId);
+}
+function setTheme(next) {
+  document.documentElement.setAttribute("data-theme", next);
+  state.theme = next;
+  saveState();
+}
+function toggleTheme() {
+  return (state.theme = state.theme === "dark" ? "light" : "dark");
+}
+function timeStr(t) {
+  return new Date(t).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" });
+}
+function autoGrow(el) {
+  el.style.height = "auto";
+  el.style.height = Math.min(el.scrollHeight, 140) + "px";
+}
+function autosizeTextarea(el) {
+  el.addEventListener("input", () => autoGrow(el));
+  autoGrow(el);
+}
+function scrollToBottom() {
+  requestAnimationFrame(() => {
+    els.messages.scrollTop = els.messages.scrollHeight;
+  });
+}
+function toast(msg) {
+  const div = document.createElement("div");
+  div.textContent = msg;
+  div.style.cssText =
+    "position:fixed;left:50%;bottom:22px;transform:translateX(-50%);background:rgba(0,0,0,.65);color:#fff;padding:8px 12px;border-radius:10px;font-size:12px;z-index:1000";
+  document.body.appendChild(div);
+  setTimeout(() => div.remove(), 1500);
+}
+function escapeHtml(s) {
+  return s.replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+}
+function linkify(s) {
+  return s.replace(
+    /(https?:\/\/[^\s]+)/g,
+    (m) => `<a href="${m}" target="_blank" rel="noreferrer" style="color: var(--secondary); text-decoration: underline;">${m}</a>`
+  );
+}
+function autoReply(text) {
+  const low = text.toLowerCase();
+  if (low.includes("hi") || low.includes("hello")) return "Hi! How can I help? 😊";
+  if (low.includes("theme")) return "Use the sun/moon button to switch themes.";
+  if (low.includes("file")) return "Attachment noted. I don’t upload files in demo mode.";
+  if (low.includes("who")) return "I’m OrbitBot — here for demos and vibes 🚀";
+  return "Got it! (This is a demo reply. Wire me to your backend when ready.)";
+}
+
+// initial select first chat on first load
+if (!state.activeId && state.chats[0]) {
+  state.activeId = state.chats[0].id;
+  saveState();
+}
+renderAll();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { BrowserRouter as Router, Route, Routes } from 'react-router-dom';
-import { RealtimeHandler } from './ws/realtime';
-import { useStore } from './state/store';
+// import { RealtimeHandler } from './ws/realtime';
+// import { useStore } from './state/store';
 
 function App() {
   const { messages } = useStore();

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import App from './App.tsx'
-import './index.css'
+import '../styles.css'
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/apps/web/styles.css
+++ b/apps/web/styles.css
@@ -1,0 +1,201 @@
+:root {
+  --bg-1: #0b1020;
+  --bg-2: #121735;
+  --glass: rgba(255, 255, 255, 0.06);
+  --border: rgba(255, 255, 255, 0.16);
+  --text: #e9e9ff;
+  --muted: #b9bbe3;
+  --primary: #8b5cf6;
+  --secondary: #06b6d4;
+  --accent: #f472b6;
+  --danger: #ef4444;
+}
+html[data-theme='light'] {
+  --bg-1: #f6f7fb;
+  --bg-2: #eaeef8;
+  --glass: rgba(255, 255, 255, 0.8);
+  --border: rgba(0, 0, 0, 0.08);
+  --text: #0f1020;
+  --muted: #4a4d70;
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+  color: var(--text);
+  background: linear-gradient(180deg, var(--bg-1), var(--bg-2));
+  min-height: 100vh;
+  overflow: hidden;
+}
+
+.bg {
+  position: fixed; inset: 0;
+  background:
+    radial-gradient(900px 900px at 15% 10%, rgba(139,92,246,.12), transparent 60%),
+    radial-gradient(800px 800px at 85% 20%, rgba(6,182,212,.12), transparent 60%),
+    radial-gradient(700px 700px at 50% 100%, rgba(244,114,182,.10), transparent 60%),
+    linear-gradient(180deg, var(--bg-1), var(--bg-2));
+  pointer-events: none;
+  z-index: 0;
+}
+.glass {
+  background: var(--glass);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  backdrop-filter: blur(12px) saturate(140%);
+  box-shadow: 0 10px 30px rgba(0,0,0,.18);
+}
+
+.topbar {
+  position: relative; z-index: 10;
+  margin: 16px;
+  padding: 10px 14px;
+  display: flex; gap: 12px; align-items: center; justify-content: space-between;
+}
+.brand { display: flex; align-items: center; gap: 10px; }
+.brand h1 {
+  margin: 0; font-size: 18px; font-weight: 700;
+  background: linear-gradient(90deg, var(--primary), var(--secondary));
+  -webkit-background-clip: text; background-clip: text; color: transparent;
+}
+.logo-orbit { position: relative; width: 20px; height: 20px; }
+.logo-orbit .planet {
+  width: 10px; height: 10px; border-radius: 50%; background: var(--primary);
+  position: absolute; top: 5px; left: 5px; box-shadow: 0 0 18px rgba(139,92,246,.6);
+}
+.logo-orbit .ring {
+  position: absolute; inset: 1px; border-radius: 50%;
+  border: 2px solid rgba(6,182,212,.7); transform: rotate(20deg);
+}
+
+.search {
+  flex: 1; display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 12px;
+  background: rgba(255,255,255,.06); border: 1px solid var(--border);
+}
+.search input {
+  flex: 1; background: transparent; border: none; outline: none;
+  color: var(--text); font-size: 14px;
+}
+.icon { color: var(--muted); }
+
+.actions { display: flex; align-items: center; gap: 10px; }
+.me img {
+  width: 28px; height: 28px; border-radius: 50%; object-fit: cover; border: 1px solid var(--border);
+}
+
+.layout {
+  position: relative; z-index: 1;
+  display: grid; grid-template-columns: 320px 1fr; gap: 16px;
+  padding: 0 16px 16px;
+  height: calc(100vh - 84px);
+}
+
+.sidebar { padding: 12px; display: flex; flex-direction: column; overflow: hidden; }
+.sidebar-head { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
+.sidebar h2 { font-size: 16px; margin: 0; }
+.chat-list { overflow: auto; padding-right: 6px; }
+.chat-item {
+  display: grid; grid-template-columns: 40px 1fr auto; gap: 10px;
+  align-items: center; padding: 10px; border-radius: 12px; cursor: pointer;
+  border: 1px solid transparent;
+}
+.chat-item:hover { background: rgba(255,255,255,.06); border-color: var(--border); }
+.chat-item.active { background: linear-gradient(90deg, rgba(139,92,246,.12), rgba(6,182,212,.10)); border-color: rgba(139,92,246,.4); }
+.chat-item .avatar { width: 40px; height: 40px; border-radius: 10px; object-fit: cover; border: 1px solid var(--border); }
+.chat-item .name { font-weight: 600; font-size: 14px; }
+.chat-item .preview { color: var(--muted); font-size: 12px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.badge { background: var(--primary); color: white; font-size: 11px; border-radius: 999px; padding: 2px 8px; }
+
+.chat {
+  display: grid; grid-template-rows: auto 1fr auto; overflow: hidden;
+}
+.chat-header {
+  display: flex; align-items: center; justify-content: space-between; padding: 12px; border-bottom: 1px solid var(--border);
+}
+.chat-meta { display: flex; align-items: center; gap: 10px; }
+.chat-meta .avatar { width: 36px; height: 36px; border-radius: 10px; border: 1px solid var(--border); }
+.chat-meta .title { margin: 0 0 2px 0; font-size: 15px; }
+.status { font-size: 12px; color: var(--muted); }
+
+.messages {
+  padding: 16px; overflow: auto; position: relative;
+  background:
+    radial-gradient(600px 600px at 85% 10%, rgba(6,182,212,.08), transparent 60%),
+    radial-gradient(500px 500px at 10% 70%, rgba(139,92,246,.08), transparent 60%);
+}
+.day-sep {
+  text-align: center; margin: 8px auto; font-size: 12px; color: var(--muted);
+}
+.msg-row { display: flex; gap: 10px; margin: 8px 0; }
+.msg-row.me { justify-content: flex-end; }
+.msg {
+  max-width: min(72%, 640px);
+  padding: 10px 12px; border-radius: 14px; border: 1px solid var(--border);
+  font-size: 14px; line-height: 1.35; white-space: pre-wrap;
+}
+.msg.me {
+  background: linear-gradient(120deg, var(--primary), var(--secondary));
+  color: #fff; border-color: transparent; border-bottom-right-radius: 6px;
+  box-shadow: 0 8px 22px rgba(139,92,246,.25);
+}
+.msg.other {
+  background: rgba(255,255,255,.07); border-bottom-left-radius: 6px;
+}
+.msg .meta { display: flex; align-items: center; gap: 8px; margin-top: 6px; font-size: 11px; color: var(--muted); }
+.msg .meta .dot { width: 6px; height: 6px; border-radius: 50%; background: var(--secondary); box-shadow: 0 0 10px var(--secondary); }
+
+.typing { display: inline-flex; gap: 4px; }
+.typing span { width: 6px; height: 6px; border-radius: 50%; background: var(--muted); opacity: .6; animation: blink 1.2s infinite; }
+.typing span:nth-child(2) { animation-delay: .2s; }
+.typing span:nth-child(3) { animation-delay: .4s; }
+@keyframes blink { 0%, 60%, 100% { opacity: .25 } 30% { opacity: .9 } }
+
+.composer {
+  display: grid; grid-template-columns: auto auto 1fr auto auto; gap: 8px;
+  padding: 10px; border-top: 1px solid var(--border);
+}
+textarea {
+  width: 100%; resize: none; border: 1px solid var(--border); border-radius: 12px;
+  padding: 10px 12px; background: rgba(255,255,255,.06); color: var(--text);
+  max-height: 140px;
+}
+textarea::placeholder { color: var(--muted); }
+
+.btn {
+  display: inline-flex; align-items: center; gap: 8px; height: 34px;
+  padding: 0 12px; border-radius: 10px; border: 1px solid var(--border);
+  background: rgba(255,255,255,.06); color: var(--text); cursor: pointer;
+}
+.btn:disabled { opacity: .5; cursor: not-allowed; }
+.btn.primary {
+  background: linear-gradient(120deg, var(--primary), var(--secondary)); color: #fff; border: none;
+  box-shadow: 0 8px 22px rgba(139,92,246,.25);
+}
+.btn.subtle { background: rgba(255,255,255,.05); }
+.btn.danger { color: #fff; background: linear-gradient(120deg, #ef4444, #f97316); border: none; }
+.icon-btn { padding: 0 10px; width: 36px; justify-content: center; }
+
+.fab {
+  position: fixed; right: 22px; bottom: 22px; width: 52px; height: 52px;
+  border-radius: 50%; display: inline-flex; align-items: center; justify-content: center;
+  border: none; cursor: pointer; z-index: 20;
+  box-shadow: 0 12px 30px rgba(0,0,0,.25);
+}
+.fab.primary { background: linear-gradient(120deg, var(--primary), var(--secondary)); color: white; }
+
+.empty { height: 100%; display: grid; place-items: center; text-align: center; padding: 16px; }
+.empty h3 { margin: 8px 0 6px; }
+.empty p { margin: 0; color: var(--muted); }
+.logo-big { position: relative; width: 70px; height: 70px; }
+.logo-big .planet { width: 24px; height: 24px; border-radius: 50%; background: var(--primary); position: absolute; top: 24px; left: 24px; box-shadow: 0 0 30px rgba(139,92,246,.6); }
+.logo-big .ring { position: absolute; inset: 2px; border: 4px solid rgba(6,182,212,.6); border-radius: 50%; transform: rotate(20deg); }
+
+.hidden { display: none; }
+
+@media (max-width: 900px) {
+  .layout { grid-template-columns: 1fr; }
+  .sidebar { height: 40vh; }
+  .chat { height: 60vh; }
+}


### PR DESCRIPTION
…ith rich chat layout in apps/web/index.html\n- Add apps/web/styles.css (glassmorphism, light/dark themes)\n- Add apps/web/main.js (localStorage chats, search, new chat, send, emoji, attachments, typing indicator, read receipts)\n- Keep React/TS code in repo untouched; demo UI runs standalone under Vite\n\nReady to wire to backend later (swap mock reply).